### PR TITLE
Corrected JRubyConf to JRubyConf.eu

### DIFF
--- a/events.md
+++ b/events.md
@@ -48,7 +48,7 @@ Hacker conference.<br>
 2014, February-March, 28-1<br>
 Conference on newest trends and techniques with jQuery.<br>
 
-* **[JRubyConf](http://jrubyconf.eu)** [[t]](https://twitter.com/jrubyconfeu) [[f]](https://www.facebook.com/jrubyconfeu), Germany, Berlin - **Y**<br>
+* **[JRubyConf.eu](http://jrubyconf.eu)** [[t]](https://twitter.com/jrubyconfeu) [[f]](https://www.facebook.com/jrubyconfeu), Germany, Berlin - **Y**<br>
 ~~2013, August, 14-15~~<br>
 Conference on JRuby, Java implementation of the Ruby programming language.<br>
 [Code of Conduct](http://2013.eurucamp.org/policies)<br>


### PR DESCRIPTION
Although the main event is currently not happening, JRubyConf.eu is the European version of the JRubyConf event in the US. The US event is organized by a different team and - to my knowledge - didn't have a CoC in 2011/12.
